### PR TITLE
JC|DK: Updated refresh to handle refreshing onto the same slide

### DIFF
--- a/js/modules/carousel.js
+++ b/js/modules/carousel.js
@@ -430,7 +430,11 @@ toolkit.carousel = (function(window, $) {
                 } else if (index > (carousel.slideCount - 1)){
                     index = carousel.slideCount - 1;
                 }
-                carousel.goto(index);
+                if (index > carousel.currentIndex) {
+                    carousel.moveSlide({index: index, start:0, end:-50});
+                } else {
+                    carousel.moveSlide({index: index, start:-50, end: 0});
+                }
             }).on('keyup',function(e){
                 switch(e.keyCode){
                     case 9: carousel.pause(); break; //tab

--- a/test/jsUnit/CarouselSpec.html
+++ b/test/jsUnit/CarouselSpec.html
@@ -260,7 +260,8 @@
                 checkActiveSlideAfterAction(function() {$('#hero').trigger('refresh', 1);}, 3, 1, 0);
                 checkActiveSlideAfterAction(function() {$('#hero').trigger('refresh', 3);}, 1, 3, 100);
                 checkActiveSlideAfterAction(function() {$('#hero').trigger('refresh', 2);}, 3, 2, 200);
-                checkActiveSlideAfterAction(function() {$('#hero').trigger('refresh', 0);}, 2, 0, 300, done);
+                checkActiveSlideAfterAction(function() {$('#hero').trigger('refresh', 2);}, 2, 2, 300);
+                checkActiveSlideAfterAction(function() {$('#hero').trigger('refresh', 0);}, 2, 0, 400, done);
             });
         });
         mocha.run();


### PR DESCRIPTION
Our QA found a bug in the previous pull request. Could this be updated?
The problem was that if you refresh onto the same slide, the 'goto' method just returned, therefore the transition didn't happen as expected.
