### PR TITLE
AG: fix for email icon wrapping onto second line on iPhone

### DIFF
--- a/grunt/sass/toolkit/components/_share.scss
+++ b/grunt/sass/toolkit/components/_share.scss
@@ -150,7 +150,7 @@
       li {
         margin: 1%;
         padding: 10px 0;
-        width: 45px;
+        width: 35px;
         text-align: center;
         a {
           width: 100%;


### PR DESCRIPTION
Reducing the width for the mobile share bar icons since it wraps onto two lines on an iPhone
