### PR TITLE
Added name and version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
-{   
+{
+    "name": "web-toolkit",
+    "version": "0.5.1",
 	"repository" : {
         "type": "git",
         "url": "https://github.com/skyglobal/web-toolkit.git"


### PR DESCRIPTION
After cloning the repo, `npm install` was failing due to required name and version keys not being present in package.json.
