### PR TITLE
BDO|HB: Fixed CSS rule that is causing Safari on iOS to ignore first cli...

### DIFF
--- a/grunt/sass/toolkit/components/_carousel.scss
+++ b/grunt/sass/toolkit/components/_carousel.scss
@@ -187,9 +187,9 @@
       &:hover {
         background: #777;
       }
-    }
-    .active {
-      background:#0073c5;
+      &.active {
+        background:#0073c5;
+      }
     }
   }
 


### PR DESCRIPTION
BDO|HB: Fixed CSS rule that is causing Safari on iOS to ignore first click because of CSS :hover rules. This particular rule should not have caused an issue, however replacing > *:hover with > span:hover fixes it
