### PR TITLE
Removed unnecessary font size declariation

### DIFF
--- a/grunt/sass/toolkit/base/_typography.scss
+++ b/grunt/sass/toolkit/base/_typography.scss
@@ -47,7 +47,6 @@ h3.smaller,
 }
 
 p {
-  font-size: 16px;
   line-height: 20px;
 }
 


### PR DESCRIPTION
This overrides the .skycom-message-container font size (cookie notice) so forces you to override it.

Removing this does not effect anything as same font size is inherited from body.

Before:

![cookies_before](https://f.cloud.github.com/assets/1391964/1530900/2d3c1660-4c58-11e3-9382-582a2ee5a76d.png)

After:

![cookies_after](https://f.cloud.github.com/assets/1391964/1530905/39d389c6-4c58-11e3-988b-dcb899cc234f.png)
