### PR TITLE
CT|HB: separated the wiki and toolkit css files

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
 		{% include skycom_resources.html %}
 
         <link rel="stylesheet" href="dist/stylesheets/wiki.css">
+        <link rel="stylesheet" href="dist/stylesheets/toolkit.css">
         <link rel="stylesheet" href="dist/fonts/skycons.css">
 
         <!--[if lt IE 10]><script type="text/javascript">

--- a/grunt/sass/wiki.scss
+++ b/grunt/sass/wiki.scss
@@ -1,4 +1,4 @@
-@import "toolkit";
+@import "toolkit/variables";
 @import "wiki/lib/solarized-light";
 
 @import "wiki/menu";


### PR DESCRIPTION
So we can see what css belongs to the toolkit and what belongs to the demonstration wiki page.
