### PR TITLE
NR: Add tick icon for use in MyPackages

### DIFF
--- a/grunt/fonts/orig/tick.svg
+++ b/grunt/fonts/orig/tick.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Sky_Talk" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="19.234px" viewBox="0 0 16 19.234" enable-background="new 0 0 16 19.234" xml:space="preserve">
+<path fill="#44AD3A" d="M15.64,3.311l-1.216-0.91c-0.178-0.133-0.425-0.094-0.558,0.086L5.15,14.529l-3.249-3.591
+	c-0.148-0.165-0.403-0.177-0.563-0.026l-1.111,1.04c-0.161,0.15-0.171,0.409-0.022,0.573l4.872,5.39
+	c0.078,0.085,0.17,0.117,0.258,0.104c0.089,0.005,0.179-0.038,0.246-0.131L15.724,3.878C15.853,3.698,15.813,3.443,15.64,3.311"/>
+</svg>


### PR DESCRIPTION
The MyPackages design makes heavy use of a 'tick' icon. The designer has created an SVG version for use in the Web Toolkit.
