### PR TITLE
BMM|ST: removed the hover state on h3 and p within the carousel

### DIFF
--- a/grunt/sass/toolkit/components/_carousel.scss
+++ b/grunt/sass/toolkit/components/_carousel.scss
@@ -269,11 +269,6 @@
 
 .skycom-notouch .skycom-carousel a{
   cursor: pointer;
-  &:hover {
-    h3, p {
-      text-decoration: underline;
-    }
-  }
 }
 
 


### PR DESCRIPTION
A fix for double underline in the carousel. 
