### PR TITLE
ST: Whole page nav fixed and added style fixes as recommended by bruno.

### DIFF
--- a/_site/_includes/components/in-page-nav/whole-page-nav.html
+++ b/_site/_includes/components/in-page-nav/whole-page-nav.html
@@ -24,11 +24,14 @@
         <li id="whole-page-seventh-tab" aria-label="seventh" role="tab" class="tab">
             <a href="#!whole-page-seventh" class="ellipsis internal-link"><span>Praesent ullamcorper tincidunt fermentum primis in faucibus orci luctus</span></a>
         </li>
-        <div class="dropdown-tab-select">
-            <a href="#!whole-page-" aria-controls="dropdown" aria-label="more tabs" class="medium">&hellip;</a>
-            <ul class="more-tabs">
 
-            </ul>
-        </div>
     </ul>
+
+    <div class="dropdown-tab-select">
+        <div href="#!" aria-hidden="true" class="medium selector">&hellip;</div>
+        <ul class="more-tabs">
+
+        </ul>
+    </div>
+
 </section>

--- a/grunt/sass/demo/_colours.scss
+++ b/grunt/sass/demo/_colours.scss
@@ -106,7 +106,7 @@
 }
 
 .demo-hex{
-  text-align: center;
+  text-align: left;
   margin-bottom:10px;
 }
 .mobile-size{

--- a/grunt/sass/toolkit/base/_buttons.scss
+++ b/grunt/sass/toolkit/base/_buttons.scss
@@ -3,7 +3,7 @@ a.btn,
   @include border-radius(5px);
   font: 16px/1em $font-family;
   padding: 0 15px;
-  height: 31px;
+  height: 32px;
   line-height: 2em;
   position: relative;
   z-index: 2;

--- a/grunt/sass/toolkit/components/_inPageNav.scss
+++ b/grunt/sass/toolkit/components/_inPageNav.scss
@@ -35,13 +35,14 @@
     line-height: 31px;
     text-align: center;
     position:relative;
-    height:44px;
+    height:46px;
     width:44px;
     margin-bottom: -1px;
     padding: 0;
     border:1px solid transparent;
     border-top:0;
     color:$secondary;
+    z-index: 1;
 
     cursor: pointer;
 
@@ -53,6 +54,11 @@
       border-bottom-color: #fff;
       color: #0073c5;
       background-color: #fff;
+      border-bottom: 1px solid transparent;
+
+      .whole-page & {
+        border-top: 1px solid #dcdcdc;
+      }
     }
   }
 }
@@ -63,8 +69,11 @@
   border: 1px solid #dcdcdc;
   position: absolute;
   right: 0;
-  top: 44px;
-  width: 300px;
+  top: 45px;
+
+  .whole-page & {
+    top: 44px;
+  }
 
   @include box-sizing(border-box);
 


### PR DESCRIPTION
Bruno's fix recommendations: http://i.imgur.com/fEQ7zqG.jpg

Demo page:
- Colour hash is now left aligned
- Button is given 1px additional height

Components:
- in page nav dropdown doesn't overlay the grey line.
- When clicking the three dots, the square div shouldn't contain a border bottom (inpage & whole page nav)
- Added border-top for the whole page nav on the square that contains the three dots. 
