### PR TITLE
Resizeend event not being turned off correctly when closing a video in the carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 2. clone your new repo onto your local machine (get the clone url from the right menu also)
   - `git clone [CLONE-URL]`
   - `git remote add upstream https://github.com/skyglobal/web-toolkit.git`
-3. Install npm on your machine
+3. Install npm on your achine
   - `echo 'export PATH=/usr/local/bin:$PATH' >> ~/.bashrc`
   - `. ~/.bashrc`
   - `mkdir /usr/local`

--- a/grunt/js/components/carousel.js
+++ b/grunt/js/components/carousel.js
@@ -343,11 +343,7 @@ toolkit.carousel = (function(video, detect) {
                 markup.indicators($this, {
                     count: carousel.slideCount,
                     onclick: function(index) {
-                        if (index !== carousel.currentIndex) {
-                            carousel.goto(index, true);
-                        } else {
-                            carousel.pause();
-                        }
+                        carousel.goto(index);
                     }
                 })
                 .terms($this)


### PR DESCRIPTION
The event to resize the video container is not being switched off correctly on video stop. This had been working in a previous version and has been broken. Refactored to go back to using the window to trigger and receive resizeend for the video player.
