### PR TITLE
Remove blockquote

### DIFF
--- a/app/src/sass/toolkit/base/_typography.scss
+++ b/app/src/sass/toolkit/base/_typography.scss
@@ -126,14 +126,6 @@ ul.grey-bullets {
   line-height: 40px;
 }
 
-
-
-
-blockquote {
-  margin: 10px;
-  font-family: Helvetica;
-}
-
 .error {
   color: $error;
 }


### PR DESCRIPTION
I spoke with Matt in the design team and he was confused as to why a blockquote was overriding the skytextregular font-family with Helvetica, especially when this Helvetica is not available on all platforms as standard.

I wish to use the blockquote element and have to override the current blockquote style, which feels unnecessary.
