### PR TITLE
Accordion item open height bug fix

### DIFF
--- a/app/_config.yml
+++ b/app/_config.yml
@@ -1,4 +1,4 @@
-version: 2.2.13
+version: 2.2.14
 include:
   - _includes
 port: 4000

--- a/app/src/js/toolkit/utils/toggle.js
+++ b/app/src/js/toolkit/utils/toggle.js
@@ -47,8 +47,8 @@ toolkit.toggle = (function(detect, event) {
             return $el.data('openHeight');
         }
 
-        $('body')
-            .append($('<div id="toggle-tmp-height" class="skycom-container"></div>')
+        $el.parent()
+            .append($('<div id="toggle-tmp-height"></div>')
             .append($el.clone().attr('style', '').removeClass(hiddenClass + ' transition ')));
         $('#toggle-tmp-height > div').append('<div class="toggle-clearfix-div clearfix clear" style="padding:1px"></div> ');
         $('#toggle-tmp-height > div').prepend('<div class="toggle-clearfix-div clearfix clear" style="padding:1px"></div> ');
@@ -63,6 +63,7 @@ toolkit.toggle = (function(detect, event) {
         }
 
         $el.data('openHeight', openHeight);
+
         $('#toggle-tmp-height').remove();
         $('.toggle-clearfix-div').remove();
 


### PR DESCRIPTION
When an accordion is located within another DOM that is not the same width as top level skycom-container (1140px on desktop), the accordion items were getting wrong open height resulting in only partially open.

https://github.com/bskyb-commerce/help-site/issues/24

This problem has been fixed by appending the temporary DOM to the element's direct wrapper instead of the body.
