### PR TITLE
ES: added support for query string in hashmanager

### DIFF
--- a/app/src/js/toolkit/utils/hash-manager.js
+++ b/app/src/js/toolkit/utils/hash-manager.js
@@ -32,6 +32,10 @@ toolkit.hashManager = (function() {
     function onHashChange(hash) {
         var evt, fn;
         hash = cleanHash((typeof hash === 'string') ? hash : location.hash);
+
+        if (hash.indexOf('?') > 1) {
+            hash = hash.split('?')[0];
+        }
         evt = getHashEvent(hash);
         if (hash && evt) {
             fn = 'callback';

--- a/test/specs/hash-manager-spec.js
+++ b/test/specs/hash-manager-spec.js
@@ -259,6 +259,36 @@ function hashManagerSpec(hash) {
                 },5);
             });
         });
+
+        describe("Query string in hashmanager support", function () {
+
+            it("using a query string in the hashbang does the callback", function (done) {
+                hash.change('');
+
+                var count = 0,
+                    callback = function () {
+                        count++;
+                    };
+
+                var hashName = 'tileTitle',
+                    queryString = '?pid=3434&altpid=3444';
+                hash.register(hashName, callback);
+
+                hash.change(hashName + queryString);
+
+                setTimeout(function() {
+                    expect(location.hash).to.equal('#!' + hashName + queryString);
+
+                    expect(count > 0).to.equal(true);
+
+                    done();
+                }, 5);
+
+
+            });
+        });
+
+
     });
 
     return describeSpec;


### PR DESCRIPTION
Added support for hashes that contains a query string
