### PR TITLE
Tags inside of <a> tags on lightbox component to be clickable

### DIFF
--- a/app/_includes/components/lightbox/default.html
+++ b/app/_includes/components/lightbox/default.html
@@ -36,6 +36,7 @@
                 <li><a href="#"><i class="skycon-chevron colour"></i>Consectetur adipisicing elit</a></li>
                 <li><a href="#"><i class="skycon-chevron colour"></i>Sed do eiusmod</a></li>
                 <li><a href="#"><i class="skycon-chevron colour"></i>Tempor incididunt</a></li>
+                <li><a href="//www.sky.com"><i class="skycon-chevron colour"></i><span>Inside span</span> outside span</a></li>
                 <li><a href="//www.sky.com"><i class="skycon-chevron colour"></i>Sky Homepage (external link)</a></li>
             </ul>
         </div>

--- a/app/src/js/toolkit/components/lightbox.js
+++ b/app/src/js/toolkit/components/lightbox.js
@@ -129,7 +129,7 @@ toolkit.lightbox = (function ($, keyboardFocus, hash, event, detect) {
                     e.preventDefault();
                     lightbox.close();
                 }
-                if ($target.attr('href')) {
+                if ($target.closest('a[href]').length) {
                     return true; // a link
                 }
                 if ($target.closest('.' + classes.content).length) {


### PR DESCRIPTION
The current way of checking click outside of the lightbox content to close the box ignores clicking event when clicking `<a>` with a tag inside, for example, `<span>` tag inside of `<a>` tag.

``` html
<a href="http://www.sky.com">Sky</a> <!-- works -->
<a href="http://www.sky.com">Go to <span>Sky</span></a> <!-- doesn't work if "Sky" is clicked -->
```

This fix checks if the click event target itself or any of its parents is `<a>` tag instead of just checking the event target alone.
