### PR TITLE
Fix in page nav ellipsis dots vertical centering on mobile

### DIFF
--- a/app/src/sass/demo/_menu.scss
+++ b/app/src/sass/demo/_menu.scss
@@ -1,18 +1,28 @@
 .main-menu.tabs-container.main-menu .primary [role=tablist]{
   margin-bottom: 0;
+
   > li.selected a,
   > li:hover a{
     border:0;
   }
 }
-.main-menu.tabs-container.main-menu .tabs{
-  margin-top: 0;
-  margin-bottom: 0;
-  border:0;
+
+.main-menu.tabs-container.main-menu{
+  &,
+  .tabs-container,
+  .tabpanel{
+    margin: 0;
+  }
+
+  .tabs{
+    border: 0;
+  }
 }
+
 .main-menu .tabpanel{
   border-bottom: 1px solid #ccc;
 }
+
 .secondary-menu,
 #toolkit-menu-tabs.stick{
   position: fixed;

--- a/app/src/sass/toolkit/components/_inPageNav.scss
+++ b/app/src/sass/toolkit/components/_inPageNav.scss
@@ -3,6 +3,8 @@ $tab-height: 45px;
 .tabpanel {
   display: none;
   width: 100%;
+  margin-top: 20px;
+
   &.selected {
     display: block;
   }
@@ -20,7 +22,7 @@ $tab-height: 45px;
   display: none;
   position: absolute;
   right: 0;
-  top: 21px;
+  top: 1px;
   z-index:10;
 
   a {
@@ -98,15 +100,16 @@ $tab-height: 45px;
 
 .tabs-container.page-nav {
   position: relative;
+  margin: 20px 0;
 
   .tabs {
     position: relative;
-    margin: 20px 0;
     padding-right: 46px;
     border-bottom: solid 1px #dcdcdc;
     border-top: solid 1px #dcdcdc;
 
   }
+
   &.whole-page .tabs {
     border-top: 0;
   }


### PR DESCRIPTION
Fix in page nav ellipsis dots vertical centering on mobile. Currently the dots sit too low on mobile, with this pull request the dots sit vertically centred on desktop and mobile.